### PR TITLE
Update cours_AG5.tex

### DIFF
--- a/Algebre_et_geometrie/cours_AG5.tex
+++ b/Algebre_et_geometrie/cours_AG5.tex
@@ -2756,7 +2756,7 @@ On peut montrer qu'en fait $(\Z/p\Z)^*$ est \slign{cyclique} d'ordre $p - 1$
 \end{exemple}
 
 \begin{defi}
-Un \textbf{corps} est un anneau $A$ où $1\neq 0$ et tout élément non nul est inversible.
+Un \textbf{corps commutatif} est un anneau commutatif $A$ où $1\neq 0$ et tout élément non nul est inversible.
 \end{defi}
 
 \begin{exem}
@@ -2764,7 +2764,7 @@ Si $p$ est premier, l'anneau $\Z/p\Z$ est un corps. Les anneaux $\Q, \R, \C$ son
 \end{exem}
 
 \begin{thm}
-Si $K$ est un corps (commutatif) fini (i.e $K$ n'a qu'un nombre fini d'éléments), alors $K^*=K\backslash \{0\}$ est cyclique.\\
+Si $K$ est un corps commutatif fini (i.e $K$ n'a qu'un nombre fini d'éléments), alors $K^*=K\backslash \{0\}$ est cyclique.\\
 En particulier, si $p$ est premier, le groupe $(\Z/p\Z)^*$ est cyclique d'ordre $p-1$.
 \end{thm}
 


### PR DESCRIPTION
Il vaut mieux définir "corps commutatif" au lieu de "corps" (dans la convention en vigueur en France, un corps n'est pas nécessairement commutatif).